### PR TITLE
Fix 6 incorrect API URLs and HTTP verbs in chef.service.ts

### DIFF
--- a/src/backend/src/main/java/com/chefpro/backendjava/common/object/dto/ChefUReqDto.java
+++ b/src/backend/src/main/java/com/chefpro/backendjava/common/object/dto/ChefUReqDto.java
@@ -1,0 +1,24 @@
+package com.chefpro.backendjava.common.object.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * DTO for partial chef profile updates (PATCH /api/chef/profile).
+ * All fields are optional: only non-null fields are updated.
+ */
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class ChefUReqDto {
+
+  private String photo;
+  private String bio;
+  private String prizes;
+  private String location;
+  private String languages;
+  private String coverPhoto;
+}

--- a/src/backend/src/main/java/com/chefpro/backendjava/controller/ChefController.java
+++ b/src/backend/src/main/java/com/chefpro/backendjava/controller/ChefController.java
@@ -146,4 +146,17 @@ public class ChefController {
       return ResponseEntity.notFound().build();
     }
   }
+
+  // ========================================
+  // AUTHENTICATED ENDPOINT - Update Chef Profile
+  // ========================================
+
+  @PatchMapping("/profile")
+  public ResponseEntity<ChefPublicDetailDto> updateChefProfile(
+    Authentication authentication,
+    @RequestBody ChefUReqDto chefUpdateDto
+  ) {
+    ChefPublicDetailDto updated = chefProfileService.updateChefProfile(authentication, chefUpdateDto);
+    return ResponseEntity.ok(updated);
+  }
 }

--- a/src/backend/src/main/java/com/chefpro/backendjava/service/ChefProfileService.java
+++ b/src/backend/src/main/java/com/chefpro/backendjava/service/ChefProfileService.java
@@ -1,11 +1,15 @@
 package com.chefpro.backendjava.service;
 
 import com.chefpro.backendjava.common.object.dto.ChefPublicDetailDto;
+import com.chefpro.backendjava.common.object.dto.ChefUReqDto;
 import com.chefpro.backendjava.common.object.dto.MenuPublicDetailDto;
+import org.springframework.security.core.Authentication;
 
 public interface ChefProfileService {
 
   ChefPublicDetailDto getChefPublicProfile(Long chefId);
 
   MenuPublicDetailDto getMenuPublicDetail(Long menuId);
+
+  ChefPublicDetailDto updateChefProfile(Authentication authentication, ChefUReqDto dto);
 }

--- a/src/backend/src/main/java/com/chefpro/backendjava/service/impl/ChefProfileServiceImpl.java
+++ b/src/backend/src/main/java/com/chefpro/backendjava/service/impl/ChefProfileServiceImpl.java
@@ -4,6 +4,7 @@ import com.chefpro.backendjava.common.object.dto.*;
 import com.chefpro.backendjava.common.object.entity.*;
 import com.chefpro.backendjava.repository.*;
 import com.chefpro.backendjava.service.ChefProfileService;
+import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -167,5 +168,25 @@ public class ChefProfileServiceImpl implements ChefProfileService {
       .dishes(dishes)
       .busyDates(busyDates)
       .build();
+  }
+
+  @Override
+  @Transactional
+  public ChefPublicDetailDto updateChefProfile(Authentication authentication, ChefUReqDto dto) {
+    Chef chef = chefRepository.findByUser_Username(authentication.getName())
+      .orElseThrow(() -> new NoSuchElementException("Chef not found for user: " + authentication.getName()));
+
+    // Partial update: only non-null DTO fields are applied
+    if (dto.getPhoto() != null)     chef.setPhoto(dto.getPhoto());
+    if (dto.getBio() != null)       chef.setBio(dto.getBio());
+    if (dto.getPrizes() != null)    chef.setPrizes(dto.getPrizes());
+    if (dto.getLocation() != null)  chef.setLocation(dto.getLocation());
+    if (dto.getLanguages() != null) chef.setLanguages(dto.getLanguages());
+    if (dto.getCoverPhoto() != null) chef.setCoverPhoto(dto.getCoverPhoto());
+
+    chefRepository.save(chef);
+
+    // Reuse the existing method to return the full updated profile
+    return getChefPublicProfile(chef.getId());
   }
 }

--- a/src/frontend/src/app/interceptors/auth-interceptor.ts
+++ b/src/frontend/src/app/interceptors/auth-interceptor.ts
@@ -18,8 +18,16 @@ export const authInterceptor: HttpInterceptorFn = (req, next) => {
     '/api/chef/search'
   ];
 
+  // Dynamic public URL patterns (e.g. /api/chef/42/profile, /api/chef/menus/7/public)
+  const publicPatterns: RegExp[] = [
+    /\/api\/chef\/\d+\/profile$/,
+    /\/api\/chef\/menus\/\d+\/public$/
+  ];
+
   // Check if the request is to a public endpoint
-  const isPublicEndpoint = publicEndpoints.some(endpoint => req.url.includes(endpoint));
+  const isPublicEndpoint =
+    publicEndpoints.some(endpoint => req.url.includes(endpoint)) ||
+    publicPatterns.some(pattern => pattern.test(req.url));
 
   if (isPublicEndpoint) {
     return next(req);

--- a/src/frontend/src/app/models/chef-detail.model.ts
+++ b/src/frontend/src/app/models/chef-detail.model.ts
@@ -1,6 +1,6 @@
 /**
- * DTOs para las respuestas públicas de perfil de chef y detalle de menú.
- * Corresponden 1:1 con los DTOs del backend (ChefPublicDetailDto, MenuPublicDetailDto).
+ * DTOs for the public chef profile and menu detail responses.
+ * Map 1:1 to the backend DTOs (ChefPublicDetailDto, MenuPublicDetailDto).
  */
 
 export interface ReviewSummary {
@@ -61,4 +61,17 @@ export interface MenuPublicDetail {
   chefPhoto: string;
   dishes: DishPublic[];
   busyDates: string[];
+}
+
+/**
+ * Interface for partial chef profile updates.
+ * All fields are optional (semantic PATCH).
+ */
+export interface ChefProfileUpdate {
+  photo?: string;
+  bio?: string;
+  prizes?: string;
+  location?: string;
+  languages?: string;
+  coverPhoto?: string;
 }

--- a/src/frontend/src/app/models/reservation.model.ts
+++ b/src/frontend/src/app/models/reservation.model.ts
@@ -1,0 +1,12 @@
+/**
+ * Interface for updating a reservation's status.
+ * Maps to the backend DTO: ReservationsUReqDto.
+ */
+export interface ReservationStatusUpdate {
+  chefId: number;
+  date: string;
+  status: 'PENDING' | 'CONFIRMED' | 'REJECTED' | 'CANCELLED';
+  numberOfDiners?: number;
+  address?: string;
+  menuId?: number;
+}

--- a/src/frontend/src/app/services/chef.service.ts
+++ b/src/frontend/src/app/services/chef.service.ts
@@ -3,7 +3,8 @@ import { HttpClient } from '@angular/common/http';
 import { environment } from '../../environments/environment';
 import { Observable } from 'rxjs';
 import { Router } from '@angular/router';
-import { ChefPublicDetail, MenuPublicDetail } from '../models/chef-detail.model';
+import { ChefProfileUpdate, ChefPublicDetail, MenuPublicDetail } from '../models/chef-detail.model';
+import { ReservationStatusUpdate } from '../models/reservation.model';
 
 @Injectable({
   providedIn: 'root'
@@ -13,50 +14,75 @@ export class ChefService {
   private router = inject(Router);
   private apiUrl = `${environment.apiUrl}`;
 
-  // Perfil público del chef (sin autenticación)
+  // ========================================
+  // PUBLIC ENDPOINTS (no authentication)
+  // ========================================
+
+  /** Chef public profile */
   getChefPublicProfile(chefId: number): Observable<ChefPublicDetail> {
     return this.http.get<ChefPublicDetail>(`${this.apiUrl}/chef/${chefId}/profile`);
   }
 
-  // Detalle público de un menú (sin autenticación)
+  /** Public menu detail */
   getMenuPublicDetail(menuId: number): Observable<MenuPublicDetail> {
     return this.http.get<MenuPublicDetail>(`${this.apiUrl}/chef/menus/${menuId}/public`);
   }
 
-  // update chef's menu
-  updateChef(chefId: number, chefData: any): Observable<any> {
-    return this.http.put<any>(`${this.apiUrl}/chefs/${chefId}`, chefData);
+  // ========================================
+  // AUTHENTICATED ENDPOINTS — CHEF PROFILE
+  // ========================================
+
+  /**
+   * Partially updates the authenticated chef's profile.
+   * PATCH /api/chef/profile — the backend identifies the chef via JWT.
+   */
+  updateChefProfile(chefData: ChefProfileUpdate): Observable<ChefPublicDetail> {
+    return this.http.patch<ChefPublicDetail>(`${this.apiUrl}/chef/profile`, chefData);
   }
 
-  // delete some menu
-  deleteMenu(menuId: number): Observable<any> {
-    return this.http.delete<any>(`${this.apiUrl}/menu/${menuId}`);
-  }
+  // ========================================
+  // AUTHENTICATED ENDPOINTS — MENUS
+  // ========================================
 
-  // obtain reservations orders
-  getChefReservations(chefId: number): Observable<any[]> {
-    return this.http.get<any[]>(`${this.apiUrl}/reservations/chef/${chefId}`);
-  }
-
-  // change reservation status
-  updateReservationStatus(chefId: number, date: string, status: string): Observable<any> {
-    const payload = { chef_ID: chefId, date: date, status: status };
-    return this.http.put<any>(`${this.apiUrl}/reservations/status`, payload);
-  }
-
-  // Create menu
+  /** Creates a new menu for the authenticated chef */
   createMenu(menuData: any): Observable<any> {
     return this.http.post(`${this.apiUrl}/chef/menus`, menuData);
   }
 
-  // create dish
+  /**
+   * Deletes a menu owned by the authenticated chef.
+   * DELETE /api/chef/menus/{menuId}
+   */
+  deleteMenu(menuId: number): Observable<void> {
+    return this.http.delete<void>(`${this.apiUrl}/chef/menus/${menuId}`);
+  }
+
+  // ========================================
+  // AUTHENTICATED ENDPOINTS — DISHES
+  // ========================================
+
+  /** Creates a new dish */
   createDish(dishData: any): Observable<any> {
     return this.http.post(`${this.apiUrl}/chef/plato`, dishData);
   }
 
-  // save allergen
-  saveAllergen(allergenData: any) {
-    return this.http.post(`${this.apiUrl}/alergenos`, allergenData);
+  // ========================================
+  // AUTHENTICATED ENDPOINTS — RESERVATIONS
+  // ========================================
+
+  /**
+   * Retrieves the authenticated chef's reservations.
+   * GET /api/reservations/chef — the backend identifies the chef via JWT.
+   */
+  getChefReservations(): Observable<any[]> {
+    return this.http.get<any[]>(`${this.apiUrl}/reservations/chef`);
   }
 
+  /**
+   * Updates the status of a reservation.
+   * PATCH /api/reservations/status — the backend expects PATCH, not PUT.
+   */
+  updateReservationStatus(payload: ReservationStatusUpdate): Observable<any> {
+    return this.http.patch<any>(`${this.apiUrl}/reservations/status`, payload);
+  }
 }


### PR DESCRIPTION
Resolves #69 

- Fix deleteMenu URL: /api/menu/{id} -> /api/chef/menus/{id}
- Fix getChefReservations: remove chefId param, use JWT auth
- Fix updateReservationStatus: change PUT to PATCH
- Remove saveAllergen (no backend endpoint exists)
- Replace updateChef with updateChefProfile (PATCH /api/chef/profile)
- Add PATCH /api/chef/profile backend endpoint (ChefController, ChefProfileService)
- Add ChefUReqDto for partial profile updates
- Add ChefProfileUpdate and ReservationStatusUpdate frontend interfaces
- Add dynamic public URL patterns to auth interceptor