### PR TITLE
feat: add dish photo support in edit-menu component

### DIFF
--- a/docs/P1-BACKEND-DISH-PHOTO-SPEC.md
+++ b/docs/P1-BACKEND-DISH-PHOTO-SPEC.md
@@ -1,0 +1,587 @@
+# P1 Backend - Dish Photo Support Implementation
+
+## Contexto
+
+**Estado Frontend**: ✅ Ya está preparado para enviar fotos de platos
+- `new-menu.component.ts` envía `photo` en Base64 al crear platos
+- `edit-menu.component.ts` ahora también envía `photo` en Base64 al actualizar platos
+- Ambos convierten las imágenes a Base64 usando `fileToBase64()` antes de enviar
+
+**Estado Backend**: ❌ NO puede recibir ni guardar fotos de platos
+- La tabla `dishes` NO tiene columna `photo`
+- La entidad `Dish.java` NO tiene campo `photo`
+- Los DTOs NO tienen campo `photo`
+- El servicio NO procesa campo `photo`
+
+---
+
+## 📋 Checklist de Implementación
+
+### 1. Migración SQL - Agregar Columna Photo a Dishes
+
+**Archivo**: `src/backend/src/main/resources/database/03-add-dish-photo-column.sql`
+
+```sql
+-- Agregar columna photo a tabla dishes para guardar imágenes en Base64
+USE chef_pro;
+
+ALTER TABLE `dishes` 
+ADD COLUMN `photo` LONGTEXT DEFAULT NULL COMMENT 'Base64 encoded dish photo' 
+AFTER `category`;
+```
+
+**Ejecutar**:
+```bash
+# Si usas MySQL Workbench o terminal MySQL:
+mysql -u root -p chef_pro < src/backend/src/main/resources/database/03-add-dish-photo-column.sql
+
+# O ejecutar manualmente en tu cliente SQL
+```
+
+---
+
+### 2. Actualizar Entidad Dish.java
+
+**Archivo**: `src/backend/src/main/java/com/chefpro/backendjava/common/object/entity/Dish.java`
+
+**Ubicación**: Después del campo `category`, antes de `allergenDishes`
+
+```java
+@Entity
+@Table(name = "dishes")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@IdClass(Dish.DishId.class)
+public class Dish {
+
+  @Id
+  @Column(name = "menu_ID", nullable = false)
+  private Long menuId;
+
+  @Id
+  @Column(name = "dish_ID", nullable = false)
+  private Long dishId;
+
+  @ManyToOne(fetch = FetchType.LAZY, optional = false)
+  @JoinColumn(name = "menu_ID", insertable = false, updatable = false)
+  private Menu menu;
+
+  @Column(name = "title", length = 150, nullable = false)
+  private String title;
+
+  @Lob
+  @Column(name = "description")
+  private String description;
+
+  @Column(name = "category", length = 50)
+  private String category;
+
+  // ✅ AGREGAR ESTE CAMPO
+  @Lob
+  @Column(name = "photo")
+  private String photo;  // Base64 encoded image data with data URI prefix
+
+  @OneToMany(mappedBy = "dish", cascade = CascadeType.ALL, orphanRemoval = true)
+  @Builder.Default
+  private List<AllergenDish> allergenDishes = new ArrayList<>();
+
+  @Data
+  @NoArgsConstructor
+  @AllArgsConstructor
+  public static class DishId implements Serializable {
+    private Long menuId;
+    private Long dishId;
+  }
+}
+```
+
+---
+
+### 3. Actualizar DTOs
+
+#### 3.1 DishCReqDto.java (Create Request DTO)
+
+**Archivo**: `src/backend/src/main/java/com/chefpro/backendjava/common/object/dto/DishCReqDto.java`
+
+```java
+package com.chefpro.backendjava.common.object.dto;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class DishCReqDto {
+
+  @JsonProperty("menu_ID")
+  private Long menuId;
+
+  @JsonProperty("dish_ID")
+  private Long dishId;
+
+  private String title;
+  private String description;
+  private String category;
+  private List<String> allergens;
+  
+  // ✅ AGREGAR ESTE CAMPO
+  private String photo;  // Base64 encoded image data (opcional, puede ser null)
+}
+```
+
+#### 3.2 DishUReqDto.java (Update Request DTO)
+
+**Archivo**: `src/backend/src/main/java/com/chefpro/backendjava/common/object/dto/DishUReqDto.java`
+
+```java
+package com.chefpro.backendjava.common.object.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class DishUReqDto {
+
+  private Long menuId;
+  private Long dishId;
+  private String title;
+  private String description;
+  private String category;
+  private List<String> allergens;
+  
+  // ✅ AGREGAR ESTE CAMPO
+  private String photo;  // Base64 encoded image data (opcional, puede ser null)
+}
+```
+
+#### 3.3 DishDto.java (Response DTO)
+
+**Archivo**: Buscar donde esté definido (probablemente en `common/object/dto/`)
+
+**Si existe**, agregar:
+```java
+private String photo;  // Base64 encoded image data
+```
+
+**Si NO existe**, necesitarás revisar qué devuelve `createDish()` y `updateDish()` actualmente. Si devuelven `Dish` directamente, está bien (el campo `photo` ya estará disponible después de actualizar la entidad).
+
+---
+
+### 4. Actualizar DishServiceImpl
+
+**Archivo**: `src/backend/src/main/java/com/chefpro/backendjava/service/impl/DishServiceImpl.java`
+
+#### 4.1 Método `createDish()`
+
+Buscar el método `createDish()` y asegurarte de que guarda el campo `photo`:
+
+```java
+@Override
+public void createDish(Authentication authentication, DishCReqDto dishCReqDto) {
+  // ... código de validación existente ...
+  
+  // Crear entidad Dish
+  Dish dish = Dish.builder()
+    .menuId(dishCReqDto.getMenuId())
+    .dishId(dishCReqDto.getDishId())
+    .title(dishCReqDto.getTitle())
+    .description(dishCReqDto.getDescription())
+    .category(dishCReqDto.getCategory())
+    .photo(dishCReqDto.getPhoto())  // ✅ AGREGAR ESTA LÍNEA
+    .build();
+  
+  // Guardar en base de datos
+  dishRepository.save(dish);
+  
+  // ... código de allergens existente ...
+}
+```
+
+#### 4.2 Método `updateDish()`
+
+Buscar el método `updateDish()` y asegurarte de que actualiza el campo `photo`:
+
+```java
+@Override
+public DishDto updateDish(Authentication authentication, DishUReqDto dishUReqDto) {
+  // ... código de validación existente ...
+  
+  // Buscar plato existente
+  Dish dish = dishRepository.findById(
+    new Dish.DishId(dishUReqDto.getMenuId(), dishUReqDto.getDishId())
+  ).orElseThrow(() -> new RuntimeException("Dish not found"));
+  
+  // Actualizar campos si vienen en el request
+  if (dishUReqDto.getTitle() != null) {
+    dish.setTitle(dishUReqDto.getTitle());
+  }
+  if (dishUReqDto.getDescription() != null) {
+    dish.setDescription(dishUReqDto.getDescription());
+  }
+  if (dishUReqDto.getCategory() != null) {
+    dish.setCategory(dishUReqDto.getCategory());
+  }
+  
+  // ✅ AGREGAR ESTAS LÍNEAS
+  if (dishUReqDto.getPhoto() != null) {
+    dish.setPhoto(dishUReqDto.getPhoto());
+  }
+  
+  // Guardar cambios
+  Dish updated = dishRepository.save(dish);
+  
+  // ... resto del código (allergens, mapeo a DTO, etc.) ...
+  
+  return mapToDishDto(updated);
+}
+```
+
+#### 4.3 Método Mapper (si existe `mapToDishDto`)
+
+Si tienes un método para convertir `Dish` → `DishDto`, asegúrate de incluir `photo`:
+
+```java
+private DishDto mapToDishDto(Dish dish) {
+  return DishDto.builder()
+    .menuId(dish.getMenuId())
+    .dishId(dish.getDishId())
+    .title(dish.getTitle())
+    .description(dish.getDescription())
+    .category(dish.getCategory())
+    .photo(dish.getPhoto())  // ✅ AGREGAR ESTA LÍNEA
+    .allergens(getAllergenNames(dish))
+    .build();
+}
+```
+
+---
+
+### 5. Consideraciones de Validación (OPCIONAL pero recomendado)
+
+#### 5.1 Validar Tamaño de Foto
+
+En `DishServiceImpl`, antes de guardar:
+
+```java
+private void validatePhotoSize(String photoBase64) {
+  if (photoBase64 == null || photoBase64.isEmpty()) {
+    return; // Photo es opcional
+  }
+  
+  // Estimar tamaño en bytes (Base64 es ~33% más grande que el binario)
+  int estimatedSizeBytes = (photoBase64.length() * 3) / 4;
+  int maxSizeBytes = 5 * 1024 * 1024; // 5 MB
+  
+  if (estimatedSizeBytes > maxSizeBytes) {
+    throw new IllegalArgumentException("Photo exceeds maximum size of 5 MB");
+  }
+}
+
+// Llamar en createDish() y updateDish():
+validatePhotoSize(dishCReqDto.getPhoto());
+```
+
+#### 5.2 Validar Formato Base64
+
+```java
+private void validatePhotoFormat(String photoBase64) {
+  if (photoBase64 == null || photoBase64.isEmpty()) {
+    return;
+  }
+  
+  // Verificar que tenga prefijo data URI válido
+  if (!photoBase64.startsWith("data:image/")) {
+    throw new IllegalArgumentException("Photo must be a valid Base64 image with data URI prefix");
+  }
+}
+```
+
+---
+
+## 🧪 Testing
+
+### Test Manual con Postman
+
+#### Test 1: Crear Plato con Foto
+
+**Request**:
+```http
+POST http://localhost:8080/api/chef/plato
+Content-Type: application/json
+Authorization: Bearer <your-jwt-token>
+
+{
+  "menu_ID": 1,
+  "dish_ID": 1,
+  "title": "Pasta Carbonara",
+  "description": "Classic Italian pasta",
+  "category": "Main Course",
+  "allergens": ["Huevos", "Lácteos"],
+  "photo": "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQEAYABgAAD..."
+}
+```
+
+**Response Esperada**:
+```http
+HTTP/1.1 201 Created
+```
+
+**Verificación**:
+```sql
+SELECT menu_ID, dish_ID, title, 
+       SUBSTRING(photo, 1, 50) AS photo_preview
+FROM dishes 
+WHERE menu_ID = 1 AND dish_ID = 1;
+```
+
+#### Test 2: Actualizar Foto de Plato
+
+**Request**:
+```http
+PATCH http://localhost:8080/api/chef/plato
+Content-Type: application/json
+Authorization: Bearer <your-jwt-token>
+
+{
+  "menuId": 1,
+  "dishId": 1,
+  "photo": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAA..."
+}
+```
+
+**Response Esperada**:
+```http
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+{
+  "menuId": 1,
+  "dishId": 1,
+  "title": "Pasta Carbonara",
+  "description": "Classic Italian pasta",
+  "category": "Main Course",
+  "allergens": ["Huevos", "Lácteos"],
+  "photo": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAA..."
+}
+```
+
+### Test Unit (JUnit)
+
+```java
+@Test
+public void testCreateDishWithPhoto() {
+  // Arrange
+  Authentication auth = mock(Authentication.class);
+  when(auth.getName()).thenReturn("chef1");
+  
+  DishCReqDto request = DishCReqDto.builder()
+    .menuId(1L)
+    .dishId(1L)
+    .title("Test Dish")
+    .description("Description")
+    .category("Main")
+    .allergens(List.of("Gluten"))
+    .photo("data:image/jpeg;base64,/9j/4AAQSkZJRg...")
+    .build();
+  
+  // Act
+  dishService.createDish(auth, request);
+  
+  // Assert
+  Dish saved = dishRepository.findById(new Dish.DishId(1L, 1L)).orElseThrow();
+  assertNotNull(saved.getPhoto());
+  assertTrue(saved.getPhoto().startsWith("data:image"));
+}
+
+@Test
+public void testUpdateDishPhoto() {
+  // Arrange
+  Dish existing = createSampleDish();
+  dishRepository.save(existing);
+  
+  String newPhoto = "data:image/png;base64,iVBORw0KGgo...";
+  DishUReqDto request = DishUReqDto.builder()
+    .menuId(1L)
+    .dishId(1L)
+    .photo(newPhoto)
+    .build();
+  
+  Authentication auth = mock(Authentication.class);
+  when(auth.getName()).thenReturn("chef1");
+  
+  // Act
+  DishDto result = dishService.updateDish(auth, request);
+  
+  // Assert
+  assertEquals(newPhoto, result.getPhoto());
+  
+  Dish updated = dishRepository.findById(new Dish.DishId(1L, 1L)).orElseThrow();
+  assertEquals(newPhoto, updated.getPhoto());
+}
+```
+
+---
+
+## 🔄 Integración con Frontend
+
+Una vez implementados estos cambios en backend:
+
+### Frontend → Backend Flow
+
+1. **Usuario sube imagen** en new-menu o edit-menu
+2. Frontend valida: max 2MB, solo imágenes
+3. Frontend convierte a Base64 usando `fileToBase64()`
+4. Frontend envía POST/PATCH con campo `photo` incluido
+5. **Backend recibe y valida** (opcional: tamaño, formato)
+6. **Backend guarda** en `dishes.photo` (LONGTEXT)
+7. Backend devuelve respuesta con `photo` incluido
+8. Frontend muestra imagen usando: `<img [src]="dish.photo" />`
+
+### Flujo de Datos
+
+```
+┌─────────────────┐
+│  Usuario        │
+│  selecciona     │
+│  imagen (File)  │
+└────────┬────────┘
+         │
+         ▼
+┌─────────────────────┐
+│  Frontend           │
+│  fileToBase64()     │
+│  → Base64 string    │
+└──────────┬──────────┘
+           │
+           │ HTTP POST/PATCH
+           │ { photo: "data:image/..." }
+           ▼
+┌─────────────────────────┐
+│  Backend                │
+│  DishServiceImpl        │
+│  → save to DB           │
+│  dishes.photo LONGTEXT  │
+└──────────┬──────────────┘
+           │
+           │ HTTP Response
+           │ { photo: "data:image/..." }
+           ▼
+┌─────────────────────┐
+│  Frontend           │
+│  <img [src]="..." > │
+│  Display photo      │
+└─────────────────────┘
+```
+
+---
+
+## ⚠️ Notas Importantes
+
+### 1. Campo Photo es Opcional
+
+- Un plato puede NO tener foto (null)
+- Frontend enviará `null` si no se seleccionó imagen
+- Backend debe manejar `null` sin errores
+
+### 2. Base64 Incluye Data URI
+
+El frontend envía:
+```
+data:image/jpeg;base64,/9j/4AAQSkZJRgABAQEAYABgAAD...
+```
+
+NO solo:
+```
+/9j/4AAQSkZJRgABAQEAYABgAAD...
+```
+
+El prefijo `data:image/jpeg;base64,` permite que el navegador use directamente en `<img src="">`.
+
+### 3. Tamaño de Columna LONGTEXT
+
+- MySQL `LONGTEXT` soporta hasta 4GB
+- Base64 de imagen de 2MB → ~2.7MB en Base64
+- `LONGTEXT` es más que suficiente
+
+### 4. Performance
+
+- Las fotos NO afectan queries de listado si usas `@Lob` con `LAZY` fetch
+- Por ahora está bien (MVP)
+- Si en futuro hay problemas de performance, migrar a almacenamiento externo (S3, Azure Blob, etc.)
+
+---
+
+## 📝 Resumen de Archivos a Modificar
+
+1. ✅ **SQL**: `src/backend/src/main/resources/database/03-add-dish-photo-column.sql`
+2. ✅ **Entity**: `Dish.java` → agregar campo `photo`
+3. ✅ **DTOs**: 
+   - `DishCReqDto.java` → agregar campo `photo`
+   - `DishUReqDto.java` → agregar campo `photo`
+   - `DishDto.java` (si existe) → agregar campo `photo`
+4. ✅ **Service**: `DishServiceImpl.java` → 
+   - Guardar `photo` en `createDish()`
+   - Actualizar `photo` en `updateDish()`
+   - Mapear `photo` en respuestas
+5. ✅ **(Opcional)** Agregar validaciones de tamaño y formato
+
+---
+
+## ✅ Checklist Final
+
+- [ ] Ejecutar migración SQL (agregar columna `photo` a `dishes`)
+- [ ] Actualizar `Dish.java` con campo `photo`
+- [ ] Actualizar `DishCReqDto.java` con campo `photo`
+- [ ] Actualizar `DishUReqDto.java` con campo `photo`
+- [ ] Actualizar `DishServiceImpl.createDish()` para guardar `photo`
+- [ ] Actualizar `DishServiceImpl.updateDish()` para actualizar `photo`
+- [ ] (Opcional) Agregar validaciones de tamaño y formato
+- [ ] Ejecutar tests unitarios
+- [ ] Test manual con Postman: crear plato con foto
+- [ ] Test manual con Postman: actualizar foto de plato
+- [ ] Verificar en DB que las fotos se guardan correctamente
+- [ ] Test integración con frontend: crear menú con fotos
+- [ ] Test integración con frontend: editar menú y cambiar fotos
+
+---
+
+## 🚀 Próximos Pasos
+
+Una vez completada esta implementación:
+
+1. **Frontend ya está listo** (commit actual en `feature/p1-frontend-photo-integration`)
+2. **Backend puede recibir y guardar fotos** (tu implementación)
+3. **Test end-to-end** juntos:
+   - Crear menú con fotos → verificar en BD
+   - Editar menú y cambiar fotos → verificar actualización
+   - Ver fotos en búsqueda y detalles → verificar visualización
+
+4. **Merge a main** cuando todo funcione
+
+---
+
+**Documento generado**: 27 de Febrero, 2026
+**Estado Frontend**: ✅ Completado en rama `feature/p1-frontend-photo-integration`
+**Estado Backend**: ⏳ Pendiente de implementación
+
+**Co-authored-by**: reyes-art-car <reyes-art-car@users.noreply.github.com>

--- a/docs/P1-FRONTEND-PLAN.md
+++ b/docs/P1-FRONTEND-PLAN.md
@@ -1,0 +1,287 @@
+# P1 - Frontend Photo Integration Plan
+
+## Estado Actual (después de pull)
+
+### ✅ Implementado en Backend
+- `PhotoUploadService` y `PhotoUploadServiceImpl` para chef photo y cover photo
+- Endpoints: `POST /api/chef/profile/photo` y `POST /api/chef/profile/cover-photo`
+- Acepta `MultipartFile`, devuelve Base64 con data URI
+- Validación: max 5MB, solo imágenes
+
+### ✅ Implementado en Frontend Service
+- `chef.service.ts` tiene métodos `uploadChefPhoto()` y `uploadChefCoverPhoto()`
+- Acepta `File`, construye `FormData`, llama al backend
+
+### ❌ Pendiente en Frontend Components
+
+1. **user-info.component.ts** - Perfil de usuario
+   - Actualmente: Redimensiona a 200x200px con Canvas y convierte a Base64 localmente
+   - Problema: No usa los nuevos métodos `uploadChefPhoto/uploadChefCoverPhoto`
+   - Estado: Funciona pero NO aprovecha validación del backend
+
+2. **edit-menu.component.ts** - Editar menú
+   - **BLOQUEANTE**: NO envía fotos al actualizar platos
+   - Falta método `fileToBase64()`
+   - Falta hacer `saveDishes()` async para manejar Promises
+   - Falta agregar campo `photo` al payload del PATCH
+
+3. **new-menu.component.ts** - Crear menú
+   - Estado: ✅ Funciona correctamente
+   - Convierte fotos a Base64 y las envía en el payload
+   - No requiere cambios inmediatos
+
+---
+
+## Plan de Acción P1 - Frontend
+
+### Fase 1: Corregir Edit Menu (PRIORIDAD ALTA) 🔴
+
+**Problema**: Cuando el usuario edita un plato y cambia su foto, la foto NO se envía al backend.
+
+**Archivos afectados**:
+- `src/frontend/src/app/components/profile/sidebar/edit-menu/edit-menu.component.ts`
+
+**Tareas**:
+1. [ ] Agregar método `fileToBase64()` (copiar de new-menu)
+2. [ ] Hacer `saveDishes()` async
+3. [ ] Convertir fotos a Base64 antes de enviar
+4. [ ] Agregar campo `photo` al payload del updateDish
+5. [ ] Agregar campo `photo` al payload del createDish (platos nuevos en menú existente)
+
+**Código requerido**:
+```typescript
+// 1. Agregar método fileToBase64
+private fileToBase64(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(String(reader.result ?? ''));
+    reader.onerror = () => reject(new Error('Error al procesar la imagen'));
+    reader.readAsDataURL(file);
+  });
+}
+
+// 2. Actualizar saveDishes para ser async
+private async saveDishes(): Promise<void> {
+  const requests: Observable<any>[] = [];
+  let nextDishId = this.getMaxDishId();
+
+  for (const dish of this.dishes) {
+    const allergens = this.mapAllergenIdsToNames(dish.allergenIds);
+    
+    // Convertir foto si existe
+    const photoBase64 = dish.photo ? await this.fileToBase64(dish.photo) : null;
+
+    if (dish.dishId) {
+      // Actualizar plato existente
+      requests.push(this.menuService.updateDish({
+        menuId: this.menuId,
+        dishId: dish.dishId,
+        title: dish.title.trim(),
+        description: dish.description.trim(),
+        category: dish.category,
+        allergens,
+        photo: photoBase64  // ✅ AGREGAR
+      }));
+    } else {
+      // Crear plato nuevo
+      nextDishId += 1;
+      dish.dishId = nextDishId;
+      requests.push(this.menuService.createDish({
+        menu_ID: this.menuId,
+        dish_ID: dish.dishId,
+        title: dish.title.trim(),
+        description: dish.description.trim(),
+        category: dish.category,
+        allergens,
+        photo: photoBase64  // ✅ AGREGAR
+      }));
+    }
+  }
+
+  if (requests.length === 0) {
+    this.isSaving = false;
+    this.router.navigate(['/profile/menus']);
+    return;
+  }
+
+  forkJoin(requests).pipe(
+    takeUntil(this.destroy$)
+  ).subscribe({
+    next: () => {
+      this.isSaving = false;
+      this.router.navigate(['/profile/menus']);
+    },
+    error: (err) => {
+      console.error('EditMenu: Error al guardar platos:', err);
+      this.isSaving = false;
+      this.errorMessage = 'No se pudieron guardar los platos. Intentalo de nuevo.';
+      this.cdr.detectChanges();
+    }
+  });
+}
+```
+
+---
+
+### Fase 2: Integrar PhotoUploadService en User Info (OPCIONAL - MEJORA) 🟡
+
+**Objetivo**: Aprovechar validación del backend en lugar de hacerla solo en frontend.
+
+**Archivos afectados**:
+- `src/frontend/src/app/components/profile/sidebar/user-info/user-info.component.ts`
+
+**Decisión requerida**: 
+- ¿Mantener sistema actual (resize en frontend + Base64)?
+- ¿O cambiar a usar `uploadChefPhoto()` del backend?
+
+**Trade-offs**:
+
+| Aspecto | Sistema Actual (Frontend) | Nuevo Sistema (Backend) |
+|---------|---------------------------|-------------------------|
+| Resize | ✅ 200x200px en Canvas | ❌ No hace resize |
+| Validación | Frontend only | ✅ Backend + Frontend |
+| Tamaño máximo | 2MB | 5MB |
+| Request size | Pequeño (~10-20KB) | Grande (~2-5MB) |
+| Proceso | Inmediato | Requiere upload |
+| Consistencia | Photo en `users.photo` | Photo en `chefs.photo` |
+
+**Estado actual de la tabla**:
+```sql
+-- users.photo (LONGTEXT) - se usa actualmente
+-- chefs.photo (VARCHAR(255)) - NO se usa, pero backend nuevo lo usa
+```
+
+**PROBLEMA IDENTIFICADO**: 
+- Backend guarda en `chefs.photo` pero frontend espera que esté en `users.photo`
+- Hay duplicación: foto puede estar en ambos lados
+
+**RECOMENDACIÓN**: 
+1. **Corto plazo**: Mantener sistema actual de user-info (funciona bien)
+2. **Medio plazo**: Coordinar con backend para decidir:
+   - ¿Foto solo en `users.photo`?
+   - ¿O solo en `chefs.photo`?
+   - ¿Sincronizar ambos?
+
+**Acción por ahora**: ⏸️ **SKIP** - No tocar user-info hasta decisión arquitectónica
+
+---
+
+### Fase 3: Validar New Menu (VERIFICACIÓN) 🟢
+
+**Objetivo**: Asegurar que new-menu funciona correctamente con el backend actualizado.
+
+**Archivos**:
+- `src/frontend/src/app/components/new-menu/new-menu.component.ts`
+
+**Tareas**:
+1. [ ] Test manual: Crear menú con fotos
+2. [ ] Verificar que las fotos aparecen en la BD (tabla `dishes.photo`)
+3. [ ] Verificar que las fotos se muestran en búsqueda/detalles
+
+**Estado**: ✅ Ya funciona (envia `photo: photoBase64` en createDish)
+
+---
+
+## Checklist de Implementación
+
+### Inmediato (Esta sesión):
+- [ ] Fix edit-menu: agregar método `fileToBase64()`
+- [ ] Fix edit-menu: hacer `saveDishes()` async
+- [ ] Fix edit-menu: enviar `photo` en payload de updateDish
+- [ ] Fix edit-menu: enviar `photo` en payload de createDish (nuevos platos)
+- [ ] Test manual: editar menú y cambiar fotos de platos
+- [ ] Test manual: agregar nuevo plato con foto a menú existente
+
+### Futuro (Siguiente PR):
+- [ ] Decisión arquitectónica: ¿dónde guardar foto de perfil? (users vs chefs)
+- [ ] Integrar uploadChefPhoto en user-info (si se decide)
+- [ ] Implementar cover photo en frontend (campo existe en BD, no en UI)
+- [ ] Agregar visualización de cover photo en perfil público
+
+### Backend (informar a compañera):
+- [ ] Agregar columna `photo LONGTEXT` a tabla `dishes` (DDL)
+- [ ] Actualizar entidad `Dish.java` con campo `photo`
+- [ ] Actualizar DTOs: `DishCReqDto`, `DishUReqDto`, `DishDto`
+- [ ] Actualizar `DishService` y `DishServiceImpl` para manejar campo `photo`
+
+---
+
+## Arquitectura de Fotos - Estado Actual
+
+### Tabla `users`
+```sql
+photo LONGTEXT DEFAULT NULL  -- Usado por auth.service.ts
+```
+- Usado por: `updateUser()` en frontend
+- Componente: `user-info.component.ts`
+- Proceso: Resize 200x200 → Base64 → Guarda en users.photo
+
+### Tabla `chefs`
+```sql
+photo varchar(255) DEFAULT NULL       -- Usado por PhotoUploadService (backend)
+cover_photo text DEFAULT NULL         -- Existe pero NO usado en frontend
+```
+- Usado por: `uploadChefPhoto()` (backend nuevo)
+- ⚠️ **INCONSISTENCIA**: Backend guarda aquí, pero frontend NO consume desde aquí
+
+### Tabla `dishes`
+```sql
+-- ❌ FALTA: columna photo (debe agregarse en migración SQL)
+```
+- Usado por: new-menu y edit-menu envían `photo` pero BD no tiene columna
+- ⚠️ **BLOQUEANTE BACKEND**: Sin esta columna, las fotos se pierden
+
+---
+
+## Testing Plan
+
+### Test 1: Crear menú con fotos
+1. Login como chef
+2. Ir a "Crear menú"
+3. Agregar 2 platos con fotos
+4. Guardar
+5. ✅ Verificar: Fotos aparecen en "Mis menús"
+
+### Test 2: Editar menú - cambiar foto
+1. Login como chef
+2. Abrir menú existente
+3. Cambiar foto de un plato
+4. Guardar
+5. ✅ Verificar: Nueva foto aparece
+
+### Test 3: Editar menú - agregar plato con foto
+1. Login como chef
+2. Abrir menú existente
+3. Agregar nuevo plato con foto
+4. Guardar
+5. ✅ Verificar: Nuevo plato con foto aparece
+
+### Test 4: Perfil - cambiar foto
+1. Login como chef
+2. Ir a perfil
+3. Cambiar foto de perfil
+4. Guardar
+5. ✅ Verificar: Nueva foto aparece en navbar y perfil público
+
+---
+
+## Notas Importantes
+
+1. **Backend ya tiene PhotoUploadService** pero solo para chef photo/cover photo, NO para dishes
+2. **Tabla dishes NO tiene columna photo** - backend debe agregarla
+3. **Frontend new-menu YA envia fotos** - listo para cuando backend agregue columna
+4. **Frontend edit-menu NO envia fotos** - esto es lo que debemos arreglar AHORA
+
+---
+
+## Próximos Pasos
+
+1. **HOY**: Corregir edit-menu para enviar fotos ✅
+2. **Informar backend**: Necesitan agregar columna `photo` a tabla `dishes`
+3. **Después**: Decisión sobre arquitectura de fotos de perfil (users vs chefs)
+
+---
+
+**Rama de trabajo**: `feature/p1-frontend-photo-integration`
+**Estado**: En progreso
+**Prioridad**: Fase 1 (Edit Menu) es bloqueante


### PR DESCRIPTION
@reyes-art-car I've finished the frontend part for dish photos. Everything is in the feature/p1-frontend-photo-integration branch.

Important document: Read docs/P1-BACKEND-DISH-PHOTO-SPEC.md - it has EVERYTHING you need to do in the backend, step by step:

SQL migration (add photo column to dishes)
Changes in Dish.java, DTOs, DishServiceImpl
Tests and validations
The frontend already sends photos in Base64 when dishes are created or edited. All that's left is for the backend to receive and save them.

If you have any questions, check the document that has the complete code with examples.

Translated with [DeepL.com](https://www.deepl.com/?utm_campaign=product&utm_source=web_translator&utm_medium=web&utm_content=copy_free_translation) (free version)@reyes-art-car I've finished the frontend part for dish photos. Everything is in the feature/p1-frontend-photo-integration branch.

Important document: Read docs/P1-BACKEND-DISH-PHOTO-SPEC.md - it has EVERYTHING you need to do in the backend, step by step:

SQL migration (add photo column to dishes)
Changes in Dish.java, DTOs, DishServiceImpl
Tests and validations
The frontend already sends photos in Base64 when dishes are created or edited. All that's left is for the backend to receive and save them.

If you have any questions, check the document that has the complete code with examples.