### PR TITLE
docs: update Hito 2 status with new profile photo logic

### DIFF
--- a/docs/PLAN-HITO2-ESTADO.md
+++ b/docs/PLAN-HITO2-ESTADO.md
@@ -1,72 +1,71 @@
-Perfecto, he analizado completamente el proyecto. Aquí está el estado actual del Hito 2:
+Estado actualizado del Hito 2 con validaciones reales en entorno Docker.
 
-## Estado del Hito 2 (Entrega HOY 27/02/2026)
+## Estado del Hito 2 (actualizado)
 
-### COMPLETADO (85-90%)
+### COMPLETADO (90-95%)
 
-| Requisito | Estado | Archivos |
-|-----------|--------|----------|
-| Sistema de Valoraciones | 100% | review-form, user-orders |
-| Dashboard Chef (Reservas) | 100% | user-orders (aceptar/rechazar/cancelar) |
-| Calendario Chef | 100% | user-calendar |
-| UI/UX Responsive | 100% | Media queries en todos los componentes |
-| Spinners de carga | 100% | service-detail, search-results, sign-in |
-| Limpieza console.log | 100% | No quedan console.log/debug |
-| Sin alert() nativos | 100% | ToastService implementado (P0) |
-| Gestión de errores HTTP | 100% | error.interceptor global |
+| Requisito | Estado | Nota |
+|-----------|--------|------|
+| Sistema de Valoraciones | 100% | Flujo funcional en frontend/backend |
+| Dashboard Chef (Reservas) | 100% | Ver/aceptar/rechazar/cancelar |
+| Calendario Chef | 100% | Integrado con reservas |
+| UI/UX Responsive | 100% | Breakpoints y layouts revisados |
+| Spinners y feedback | 100% | Toasts + estados de carga |
+| Limpieza P0 | 100% | Sin `console.log/debug` ni `alert/confirm` nativos |
+| Gestión errores HTTP | 100% | interceptor global |
+| Foto de perfil (ambos roles) | 100% | Validado con flujo `auth/profile` |
 
-### PENDIENTE (10-15%)
+### PENDIENTE
 
-1. CRITICO - Fotos de Perfil NO usan backend
-   - Backend tiene uploadChefPhoto() y uploadChefCoverPhoto() OK
-   - Frontend [user-info.component.ts](src/frontend/src/app/components/profile/sidebar/user-info/user-info.component.ts) no los usa
-   - Problema: Convierte localmente y guarda en users.photo via authService
-   - Deberia: Usar chefService.uploadChefPhoto() -> backend PhotoUploadService
+1. MEDIO - Cover Photo sin UI en perfil
+   - Backend soporta subida de cover photo.
+   - Frontend aún no tiene input/preview para gestionarla.
 
-2. MEDIO - Cover Photo NO tiene UI
-   - Backend soporta cover photo OK
-   - Frontend no tiene input para subirla
-   - Solo se visualiza si ya existe
+2. MEDIO - Fotos de platos dependen de backend
+   - Frontend ya envía Base64 en alta/edición.
+   - Falta cerrar backend/BD (`dishes.photo`) por parte de backend.
 
-3. MEDIO - Fotos de Platos
-   - Frontend envia Base64 en createDish/updateDish (completado en P1)
-   - Backend necesita columna photo en tabla dishes (tu companera trabajando)
+3. BAJO - Ajustes finales de hardening
+   - Verificación final de consola limpia en casos límite.
+   - Validación end-to-end final antes de cierre de Hito 2.
 
 ---
 
-## Plan de Accion URGENTE (para HOY)
+## Cambio de decisión técnica (importante)
 
-### Prioridad 1: Integrar uploadChefPhoto en user-info
+Inicialmente se planteó mover la foto de perfil a `/api/chef/profile/photo`.
 
-Problema: user-info hace resize local y no usa el endpoint backend dedicado.
+Tras pruebas reales, se confirmó que ese endpoint está protegido por `ROLE_CHEF`, lo que provoca `403` para otros roles. Como la foto de perfil debe funcionar para todos los usuarios, se mantiene el flujo común:
 
-Solucion: Modificar [user-info.component.ts](src/frontend/src/app/components/profile/sidebar/user-info/user-info.component.ts) para:
-1. Usar chefService.uploadChefPhoto(file) en lugar de resizeAndConvertImage()
-2. Permitir que backend maneje la foto (max 5MB)
-3. Actualizar el profileForm con la URL devuelta
+- Frontend: selección + resize local (200x200, máx 2MB)
+- Persistencia: `PUT /api/auth/profile`
+- Resultado: funcional para CHEF y DINER
 
-Tiempo estimado: 15-20 minutos
-
----
-
-### Prioridad 2: Agregar UI para Cover Photo
-
-Problema: Backend soporta cover photo pero frontend no tiene input.
-
-Solucion: Agregar en user-info:
-1. Otro input[type="file"] para cover photo
-2. Preview de cover photo actual
-3. Boton para cambiarla usando chefService.uploadChefCoverPhoto(file)
-
-Tiempo estimado: 20-30 minutos
+Esta decisión mantiene compatibilidad con el modelo actual y evita regresiones de permisos.
 
 ---
 
-## Empezamos
+## Plan de actuación (siguiente bloque)
 
-Tenemos dos tareas rapidas para completar el Hito 2 al 100%:
+### Prioridad 1: UI de Cover Photo en perfil
 
-1. Conectar user-info con uploadChefPhoto (critico - 15 min)
-2. Agregar UI para cover photo (recomendado - 25 min)
+Implementar en `user-info`:
+1. Input de subida de cover photo.
+2. Vista previa de cover actual.
+3. Botón cambiar/eliminar cover.
+4. Feedback visual (loading + toast de éxito/error).
 
-Creo la rama de trabajo y empezamos con la Prioridad 1.
+### Prioridad 2: Cierre integración fotos de platos
+
+Una vez backend confirme columna/endpoint de platos:
+1. Validar guardado real en BD.
+2. Verificar renderizado en resultados/detalle.
+3. Prueba E2E de alta y edición con imagen.
+
+---
+
+## Resumen ejecutivo
+
+- La foto de perfil ya funciona para ambos roles y queda cerrada.
+- El siguiente trabajo es Cover Photo UI + cierre de fotos de platos con backend.
+- El proyecto está en fase final para completar Hito 2.


### PR DESCRIPTION
Reflect decision to keep auth/profile flow for profile photos (CHEF and DINER), update completion status, and set next priorities.