### PR TITLE
fix: add nested MySQL env fallbacks for Railway datasource config

### DIFF
--- a/docs/RAILWAY-DEPLOY.md
+++ b/docs/RAILWAY-DEPLOY.md
@@ -122,33 +122,26 @@ railway up
 
 1. En Railway → clic en el servicio del **backend** (no el de MySQL)
 2. Pestaña **Variables** → **+ New Variable**
-3. Añade estas (opcion recomendada -- referencias directas a MySQL):
+3. Railway inyecta automaticamente las variables `MYSQLHOST`, `MYSQLPORT`, `MYSQLDATABASE`, `MYSQLUSER` y `MYSQLPASSWORD` desde el servicio MySQL. `application.yml` las lee directamente, asi que **no necesitas anadir variables de conexion manualmente**. Solo anade estas opcionales:
 
 | Variable | Valor | Para qué sirve |
 |----------|-------|-----------------|
-| `MYSQL_HOST` | `${{MySQL.MYSQL_HOST}}` | Host de la BD |
-| `MYSQL_PORT` | `${{MySQL.MYSQL_PORT}}` | Puerto de la BD |
-| `MYSQL_DATABASE` | `chef_pro` | Nombre de la base de datos |
-| `MYSQL_USER` | `${{MySQL.MYSQL_USER}}` | Usuario de la BD |
-| `MYSQL_PASSWORD` | `${{MySQL.MYSQL_PASSWORD}}` | Contraseña de la BD |
 | `SPRING_JPA_SHOW_SQL` | `false` | No imprimir SQL en los logs |
 | `LOG_LEVEL_SQL` | `WARN` | Reducir verbosidad |
 | `LOG_LEVEL_BIND` | `WARN` | Reducir verbosidad |
 
-`application.yml` construye la URL JDBC automaticamente a partir de `MYSQL_HOST`, `MYSQL_PORT` y `MYSQL_DATABASE`, asi que no necesitas montar la URL a mano.
-
 <details>
-<summary>Alternativa: usar SPRING_DATASOURCE_* directamente</summary>
+<summary>Alternativa: usar SPRING_DATASOURCE_* para sobreescribir</summary>
+
+Si necesitas sobreescribir la URL JDBC (por ejemplo, para anadir parametros de conexion):
 
 | Variable | Valor |
 |----------|-------|
-| `SPRING_DATASOURCE_URL` | `jdbc:mysql://${{MySQL.MYSQL_HOST}}:${{MySQL.MYSQL_PORT}}/chef_pro` |
-| `SPRING_DATASOURCE_USERNAME` | `${{MySQL.MYSQL_USER}}` |
-| `SPRING_DATASOURCE_PASSWORD` | `${{MySQL.MYSQL_PASSWORD}}` |
+| `SPRING_DATASOURCE_URL` | `jdbc:mysql://${{MySQL.MYSQLHOST}}:${{MySQL.MYSQLPORT}}/chef_pro` |
+| `SPRING_DATASOURCE_USERNAME` | `${{MySQL.MYSQLUSER}}` |
+| `SPRING_DATASOURCE_PASSWORD` | `${{MySQL.MYSQLPASSWORD}}` |
 
 </details>
-
-La sintaxis `${{MySQL.VARIABLE}}` es una referencia entre servicios de Railway. Si la BD cambia de direccion internamente, el backend se actualiza solo.
 
 En local no afecta: `application.yml` tiene valores por defecto (localhost:3306/chef_pro), asi que sin las variables de entorno usa la configuracion local.
 

--- a/src/backend/src/main/resources/application.yml
+++ b/src/backend/src/main/resources/application.yml
@@ -7,9 +7,9 @@ jwt:
 
 spring:
   datasource:
-    url: ${SPRING_DATASOURCE_URL:jdbc:mysql://${MYSQL_HOST:localhost}:${MYSQL_PORT:3306}/${MYSQL_DATABASE:chef_pro}}
-    username: ${SPRING_DATASOURCE_USERNAME:${MYSQL_USER:root}}
-    password: ${SPRING_DATASOURCE_PASSWORD:${MYSQL_PASSWORD:chefpr01;}}
+    url: ${SPRING_DATASOURCE_URL:jdbc:mysql://${MYSQLHOST:localhost}:${MYSQLPORT:3306}/${MYSQLDATABASE:chef_pro}}
+    username: ${SPRING_DATASOURCE_USERNAME:${MYSQLUSER:root}}
+    password: ${SPRING_DATASOURCE_PASSWORD:${MYSQLPASSWORD:chefpr01;}}
 
   jpa:
     hibernate:


### PR DESCRIPTION
- application.yml now resolves JDBC URL from MYSQL_HOST, MYSQL_PORT, MYSQL_DATABASE, MYSQL_USER, MYSQL_PASSWORD when SPRING_DATASOURCE_* variables are not set
- Updated RAILWAY-DEPLOY.md section 5 with simpler variable setup

Closes #132