### PR TITLE
fix: allow workflow_dispatch to trigger production deploy

### DIFF
--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -43,9 +43,9 @@ env:
   VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
 
 jobs:
-  # ─── PRODUCTION deploy (push to main) ────────────────────
+  # ─── PRODUCTION deploy (push to main or manual trigger) ──
   deploy-production:
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     environment: production
 


### PR DESCRIPTION
The deploy-production job condition only checked for push events, so manual workflow_dispatch triggers were silently skipped. Add workflow_dispatch to the condition so manual runs deploy to production.