### PR TITLE
feat: add auth redirect guard to prevent logged-in users from accessi…

### DIFF
--- a/src/frontend/src/app/app.routes.ts
+++ b/src/frontend/src/app/app.routes.ts
@@ -18,6 +18,7 @@ import { UserCalendarComponent } from './components/profile/sidebar/user-calenda
 import { UserOrdersComponent } from './components/profile/sidebar/user-orders/user-orders.component';
 import { CancellationPoliciesComponent } from './components/cancellation-policies/cancellation-policies.component';
 import { PrivacyPolicyComponent } from './components/privacy-policy/privacy-policy.component';
+import { authRedirectGuard } from './guards/auth-redirect.guard';
 
 export const routes: Routes = [
 
@@ -43,10 +44,10 @@ export const routes: Routes = [
   // service-detail root
   { path: 'service-detail/:type/:id', component: ServiceDetailPageComponent },
 
-  // login root
-  { path: 'login', component: LoginComponent },
-  // signin root
-  { path: 'signIn', component: SignInComponent },
+  // login root (redirect to profile if already authenticated)
+  { path: 'login', component: LoginComponent, canActivate: [authRedirectGuard] },
+  // signin root (redirect to profile if already authenticated)
+  { path: 'signIn', component: SignInComponent, canActivate: [authRedirectGuard] },
 
   //profile root
   {

--- a/src/frontend/src/app/guards/auth-redirect.guard.ts
+++ b/src/frontend/src/app/guards/auth-redirect.guard.ts
@@ -1,0 +1,25 @@
+import { inject } from '@angular/core';
+import { Router } from '@angular/router';
+import { AuthService } from '../services/auth.service';
+import { map } from 'rxjs/operators';
+
+/**
+ * Guard to prevent authenticated users from accessing login/signup pages
+ * Redirects logged-in users to their profile page
+ */
+export const authRedirectGuard = () => {
+  const authService = inject(AuthService);
+  const router = inject(Router);
+
+  return authService.user$.pipe(
+    map(user => {
+      if (user) {
+        // User is authenticated, redirect to profile
+        router.navigate(['/profile']);
+        return false;
+      }
+      // User is not authenticated, allow access to login/signup
+      return true;
+    })
+  );
+};


### PR DESCRIPTION
…ng login pages

- Create authRedirectGuard functional guard in guards/auth-redirect.guard.ts
- Guard checks authService.user$ observable for authentication state
- Redirects authenticated users to /profile automatically
- Apply canActivate guard to /login and /signIn routes
- Prevents navigation flow breaking when logged-in users try to access auth pages
- Returns false and redirects if user exists, true if user is null (allows access)