### PR TITLE
fix: corregir errores de compilación que impedían arrancar con docker compose

### DIFF
--- a/src/backend/pom.xml
+++ b/src/backend/pom.xml
@@ -106,6 +106,7 @@
                         <path>
                             <groupId>org.projectlombok</groupId>
                             <artifactId>lombok</artifactId>
+                            <version>${lombok.version}</version>
                         </path>
                     </annotationProcessorPaths>
                 </configuration>

--- a/src/backend/src/main/java/com/chefpro/backendjava/common/config/CorsConfig.java
+++ b/src/backend/src/main/java/com/chefpro/backendjava/common/config/CorsConfig.java
@@ -3,13 +3,12 @@ package com.chefpro.backendjava.common.config;
 import java.util.Arrays;
 import java.util.List;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
-import org.springframework.web.servlet.config.annotation.CorsRegistry;
-import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
 public class CorsConfig {
@@ -31,34 +30,5 @@ public class CorsConfig {
     UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
     source.registerCorsConfiguration("/**", config);
     return source;
-  }
-
-  @Bean
-  public CorsConfigurationSource corsConfigurationSource() {
-    CorsConfiguration config = new CorsConfiguration();
-    config.setAllowedOriginPatterns(List.of("*"));
-    config.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"));
-    config.setAllowedHeaders(List.of("*"));
-    config.setAllowCredentials(true);
-    config.setMaxAge(3600L);
-
-    UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
-    source.registerCorsConfiguration("/**", config);
-    return source;
-  }
-
-  @Bean
-  public WebMvcConfigurer corsConfigurer() {
-    return new WebMvcConfigurer() {
-      @Override
-      public void addCorsMappings(CorsRegistry registry) {
-        registry.addMapping("/**")
-          .allowedOriginPatterns("*")
-          .allowedMethods("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS")
-          .allowedHeaders("*")
-          .allowCredentials(true)
-          .maxAge(3600);
-      }
-    };
   }
 }

--- a/src/backend/src/main/java/com/chefpro/backendjava/common/object/dto/MenuCReqDto.java
+++ b/src/backend/src/main/java/com/chefpro/backendjava/common/object/dto/MenuCReqDto.java
@@ -4,6 +4,7 @@ import java.math.BigDecimal;
 import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 import jakarta.validation.constraints.DecimalMin;
 import jakarta.validation.constraints.NotBlank;

--- a/src/backend/src/main/java/com/chefpro/backendjava/common/object/dto/MenuDTO.java
+++ b/src/backend/src/main/java/com/chefpro/backendjava/common/object/dto/MenuDTO.java
@@ -20,7 +20,7 @@ public class MenuDTO {
     private String title;
     private String description;
 
-    private List<DishSummaryDto> dishes;
+    private List<DishDto> dishes;
     private Set<String> allergens;
 
     private BigDecimal pricePerPerson;

--- a/src/backend/src/main/java/com/chefpro/backendjava/controller/ChefController.java
+++ b/src/backend/src/main/java/com/chefpro/backendjava/controller/ChefController.java
@@ -4,6 +4,7 @@ import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Map;
+import java.util.NoSuchElementException;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
@@ -140,7 +141,11 @@ public class ChefController {
   @Operation(summary = "Ver perfil público de un chef", description = "Devuelve el perfil completo de un chef: datos personales, menús, reseñas y fechas ocupadas. Endpoint público.")
   @GetMapping("/{chefId}/profile")
   public ResponseEntity<ChefPublicDetailDto> getChefPublicProfile(@PathVariable Long chefId) {
-    return ResponseEntity.ok(chefProfileService.getChefPublicProfile(chefId));
+    try {
+      return ResponseEntity.ok(chefProfileService.getChefPublicProfile(chefId));
+    } catch (NoSuchElementException e) {
+      return ResponseEntity.notFound().build();
+    }
   }
 
   @Operation(summary = "Ver detalle público de un menú", description = "Devuelve el detalle de un menú con sus platos, alérgenos (IDs de reglamento UE) y fechas ocupadas del chef. Endpoint público.")

--- a/src/backend/src/main/java/com/chefpro/backendjava/service/impl/MenuServiceImpl.java
+++ b/src/backend/src/main/java/com/chefpro/backendjava/service/impl/MenuServiceImpl.java
@@ -8,7 +8,7 @@ import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.chefpro.backendjava.common.object.dto.DishSummaryDto;
+import com.chefpro.backendjava.common.object.dto.DishDto;
 import com.chefpro.backendjava.common.object.dto.MenuCReqDto;
 import com.chefpro.backendjava.common.object.dto.MenuDTO;
 import com.chefpro.backendjava.common.object.dto.MenuUReqDto;
@@ -55,7 +55,7 @@ public class MenuServiceImpl implements MenuService {
     Menu saved = menuRepository.save(menu);
 
     return MenuDTO.builder()
-      .id(saved.getId())
+      .menuId(saved.getId())
       .title(saved.getTitle())
       .description(saved.getDescription())
       .pricePerPerson(saved.getPricePerPerson())
@@ -169,7 +169,7 @@ public class MenuServiceImpl implements MenuService {
       .collect(Collectors.toSet());
 
     return MenuDTO.builder()
-      .id(menu.getId())
+      .menuId(menu.getId())
       .title(menu.getTitle())
       .description(menu.getDescription())
       .pricePerPerson(menu.getPricePerPerson())

--- a/src/backend/src/test/java/com/chefpro/controller/ChefControllerTest.java
+++ b/src/backend/src/test/java/com/chefpro/controller/ChefControllerTest.java
@@ -50,7 +50,7 @@ class ChefControllerTest {
     MenuDTO menu = mock(MenuDTO.class);
     when(menuService.listByChef(authentication)).thenReturn(List.of(menu));
 
-    List<MenuDTO> result = controller.getMenusDelChef(authentication);
+    List<MenuDTO> result = controller.listarMenusChef(authentication);
 
     assertNotNull(result);
     assertEquals(1, result.size());
@@ -61,7 +61,7 @@ class ChefControllerTest {
   void getMenusDelChef_serviceThrows_propagatesException() {
     when(menuService.listByChef(authentication)).thenThrow(new RuntimeException("DB error"));
 
-    assertThrows(RuntimeException.class, () -> controller.getMenusDelChef(authentication));
+    assertThrows(RuntimeException.class, () -> controller.listarMenusChef(authentication));
     verify(menuService).listByChef(authentication);
   }
 
@@ -73,7 +73,7 @@ class ChefControllerTest {
     MenuDTO created = mock(MenuDTO.class);
     when(menuService.createMenu(req, authentication)).thenReturn(created);
 
-    ResponseEntity<MenuDTO> response = controller.crearMenu(req, authentication);
+    ResponseEntity<MenuDTO> response = controller.createMenu(req, authentication);
 
     assertEquals(201, response.getStatusCode().value());
     assertEquals(created, response.getBody());
@@ -85,7 +85,7 @@ class ChefControllerTest {
     MenuCReqDto req = mock(MenuCReqDto.class);
     when(menuService.createMenu(req, authentication)).thenThrow(new IllegalArgumentException("Invalid data"));
 
-    assertThrows(IllegalArgumentException.class, () -> controller.crearMenu(req, authentication));
+    assertThrows(IllegalArgumentException.class, () -> controller.createMenu(req, authentication));
     verify(menuService).createMenu(req, authentication);
   }
 
@@ -95,7 +95,7 @@ class ChefControllerTest {
   void deleteMenu_success_returns204() {
     doNothing().when(menuService).deleteMenu(authentication, 1L);
 
-    ResponseEntity<Void> response = controller.deleteMenu(authentication, 1L);
+    ResponseEntity<Void> response = controller.eliminarMenu(authentication, 1L);
 
     assertEquals(204, response.getStatusCode().value());
     verify(menuService).deleteMenu(authentication, 1L);
@@ -105,7 +105,7 @@ class ChefControllerTest {
   void deleteMenu_serviceThrows_propagatesException() {
     doThrow(new NoSuchElementException("Menu not found")).when(menuService).deleteMenu(authentication, 99L);
 
-    assertThrows(NoSuchElementException.class, () -> controller.deleteMenu(authentication, 99L));
+    assertThrows(NoSuchElementException.class, () -> controller.eliminarMenu(authentication, 99L));
     verify(menuService).deleteMenu(authentication, 99L);
   }
 
@@ -117,7 +117,7 @@ class ChefControllerTest {
     MenuDTO updated = mock(MenuDTO.class);
     when(menuService.updateMenu(authentication, req)).thenReturn(updated);
 
-    MenuDTO result = controller.patchMenu(authentication, req);
+    MenuDTO result = controller.actualizarMenu(authentication, req);
 
     assertEquals(updated, result);
     verify(menuService).updateMenu(authentication, req);
@@ -128,7 +128,7 @@ class ChefControllerTest {
     MenuUReqDto req = mock(MenuUReqDto.class);
     when(menuService.updateMenu(authentication, req)).thenThrow(new RuntimeException("Update failed"));
 
-    assertThrows(RuntimeException.class, () -> controller.patchMenu(authentication, req));
+    assertThrows(RuntimeException.class, () -> controller.actualizarMenu(authentication, req));
     verify(menuService).updateMenu(authentication, req);
   }
 
@@ -139,7 +139,7 @@ class ChefControllerTest {
     MenuDTO menu = mock(MenuDTO.class);
     when(menuService.listAllMenus()).thenReturn(List.of(menu));
 
-    ResponseEntity<List<MenuDTO>> response = controller.getAllMenusPublic();
+    ResponseEntity<List<MenuDTO>> response = controller.listarMenusPublicos();
 
     assertEquals(200, response.getStatusCode().value());
     assertEquals(1, response.getBody().size());
@@ -150,7 +150,7 @@ class ChefControllerTest {
   void getAllMenusPublic_serviceThrows_propagatesException() {
     when(menuService.listAllMenus()).thenThrow(new RuntimeException("Service failure"));
 
-    assertThrows(RuntimeException.class, () -> controller.getAllMenusPublic());
+    assertThrows(RuntimeException.class, () -> controller.listarMenusPublicos());
     verify(menuService).listAllMenus();
   }
 
@@ -161,7 +161,7 @@ class ChefControllerTest {
     DishDto dish = mock(DishDto.class);
     when(dishService.getDish(authentication, "pasta")).thenReturn(List.of(dish));
 
-    List<DishDto> result = controller.getPlato(authentication, "pasta");
+    List<DishDto> result = controller.getDishes(authentication, "pasta");
 
     assertEquals(1, result.size());
     verify(dishService).getDish(authentication, "pasta");
@@ -171,7 +171,7 @@ class ChefControllerTest {
   void getPlato_serviceThrows_propagatesException() {
     when(dishService.getDish(authentication, null)).thenThrow(new RuntimeException("Error"));
 
-    assertThrows(RuntimeException.class, () -> controller.getPlato(authentication, null));
+    assertThrows(RuntimeException.class, () -> controller.getDishes(authentication, null));
     verify(dishService).getDish(authentication, null);
   }
 
@@ -182,7 +182,7 @@ class ChefControllerTest {
     DishCReqDto req = mock(DishCReqDto.class);
     doNothing().when(dishService).createDish(authentication, req);
 
-    ResponseEntity<DishDto> response = controller.createPlato(authentication, req);
+    ResponseEntity<Void> response = controller.createDish(authentication, req);
 
     assertEquals(201, response.getStatusCode().value());
     verify(dishService).createDish(authentication, req);
@@ -193,7 +193,7 @@ class ChefControllerTest {
     DishCReqDto req = mock(DishCReqDto.class);
     doThrow(new IllegalArgumentException("Invalid dish")).when(dishService).createDish(authentication, req);
 
-    assertThrows(IllegalArgumentException.class, () -> controller.createPlato(authentication, req));
+    assertThrows(IllegalArgumentException.class, () -> controller.createDish(authentication, req));
     verify(dishService).createDish(authentication, req);
   }
 
@@ -203,7 +203,7 @@ class ChefControllerTest {
   void deletePlato_success_returns204() {
     doNothing().when(dishService).deleteDish(authentication, 1L, 2L);
 
-    ResponseEntity<Void> response = controller.deletePlato(authentication, 1L, 2L);
+    ResponseEntity<Void> response = controller.deleteDish(authentication, 1L, 2L);
 
     assertEquals(204, response.getStatusCode().value());
     verify(dishService).deleteDish(authentication, 1L, 2L);
@@ -213,7 +213,7 @@ class ChefControllerTest {
   void deletePlato_serviceThrows_propagatesException() {
     doThrow(new NoSuchElementException("Dish not found")).when(dishService).deleteDish(authentication, 1L, 99L);
 
-    assertThrows(NoSuchElementException.class, () -> controller.deletePlato(authentication, 1L, 99L));
+    assertThrows(NoSuchElementException.class, () -> controller.deleteDish(authentication, 1L, 99L));
     verify(dishService).deleteDish(authentication, 1L, 99L);
   }
 
@@ -225,7 +225,7 @@ class ChefControllerTest {
     DishDto updated = mock(DishDto.class);
     when(dishService.updateDish(authentication, req)).thenReturn(updated);
 
-    ResponseEntity<DishDto> response = controller.patchPlato(authentication, req);
+    ResponseEntity<DishDto> response = controller.updateDish(authentication, req);
 
     assertEquals(200, response.getStatusCode().value());
     assertEquals(updated, response.getBody());
@@ -237,7 +237,7 @@ class ChefControllerTest {
     DishUReqDto req = mock(DishUReqDto.class);
     when(dishService.updateDish(authentication, req)).thenThrow(new RuntimeException("Update failed"));
 
-    assertThrows(RuntimeException.class, () -> controller.patchPlato(authentication, req));
+    assertThrows(RuntimeException.class, () -> controller.updateDish(authentication, req));
     verify(dishService).updateDish(authentication, req);
   }
 
@@ -302,7 +302,7 @@ class ChefControllerTest {
     MenuPublicDetailDto dto = mock(MenuPublicDetailDto.class);
     when(chefProfileService.getMenuPublicDetail(5L)).thenReturn(dto);
 
-    ResponseEntity<MenuPublicDetailDto> response = controller.getMenuPublicDetail(5L);
+    ResponseEntity<MenuPublicDetailDto> response = controller.obtenerDetalleMenuPublico(5L);
 
     assertEquals(200, response.getStatusCode().value());
     assertEquals(dto, response.getBody());
@@ -313,7 +313,7 @@ class ChefControllerTest {
   void getMenuPublicDetail_notFound_returns404() {
     when(chefProfileService.getMenuPublicDetail(999L)).thenThrow(new NoSuchElementException());
 
-    ResponseEntity<MenuPublicDetailDto> response = controller.getMenuPublicDetail(999L);
+    ResponseEntity<MenuPublicDetailDto> response = controller.obtenerDetalleMenuPublico(999L);
 
     assertEquals(404, response.getStatusCode().value());
     verify(chefProfileService).getMenuPublicDetail(999L);

--- a/src/backend/src/test/java/com/chefpro/controller/ReservationControllerTest.java
+++ b/src/backend/src/test/java/com/chefpro/controller/ReservationControllerTest.java
@@ -87,7 +87,7 @@ class ReservationControllerTest {
         ReservationsCReqDto req = mock(ReservationsCReqDto.class);
         doNothing().when(reservationService).createReservations(req, authentication);
 
-        ResponseEntity<Void> response = controller.crearReservas(req, authentication);
+        ResponseEntity<Void> response = controller.createReservation(req, authentication);
 
         assertEquals(201, response.getStatusCode().value());
         verify(reservationService).createReservations(req, authentication);
@@ -99,7 +99,7 @@ class ReservationControllerTest {
         doThrow(new IllegalArgumentException("Invalid reservation"))
             .when(reservationService).createReservations(req, authentication);
 
-        assertThrows(IllegalArgumentException.class, () -> controller.crearReservas(req, authentication));
+        assertThrows(IllegalArgumentException.class, () -> controller.createReservation(req, authentication));
         verify(reservationService).createReservations(req, authentication);
     }
 
@@ -110,7 +110,7 @@ class ReservationControllerTest {
         LocalDate date = LocalDate.of(2025, 8, 20);
         doNothing().when(reservationService).deleteReservation(authentication, 1L, date);
 
-        ResponseEntity<Void> response = controller.deleteReserva(authentication, 1L, date);
+        ResponseEntity<Void> response = controller.deleteReservation(authentication, 1L, date);
 
         assertEquals(204, response.getStatusCode().value());
         verify(reservationService).deleteReservation(authentication, 1L, date);
@@ -122,7 +122,7 @@ class ReservationControllerTest {
         doThrow(new NoSuchElementException("Reservation not found"))
             .when(reservationService).deleteReservation(authentication, 99L, date);
 
-        assertThrows(NoSuchElementException.class, () -> controller.deleteReserva(authentication, 99L, date));
+        assertThrows(NoSuchElementException.class, () -> controller.deleteReservation(authentication, 99L, date));
         verify(reservationService).deleteReservation(authentication, 99L, date);
     }
 

--- a/src/backend/src/test/java/com/chefpro/service/impl/ChefProfileServiceTest.java
+++ b/src/backend/src/test/java/com/chefpro/service/impl/ChefProfileServiceTest.java
@@ -5,6 +5,7 @@ import com.chefpro.backendjava.common.object.dto.ChefUReqDto;
 import com.chefpro.backendjava.common.object.dto.MenuPublicDetailDto;
 import com.chefpro.backendjava.common.object.entity.*;
 import com.chefpro.backendjava.repository.*;
+import com.chefpro.backendjava.common.util.ChefResolver;
 import com.chefpro.backendjava.service.ChefProfileService;
 import com.chefpro.backendjava.service.impl.ChefProfileServiceImpl;
 import org.junit.jupiter.api.BeforeEach;
@@ -27,6 +28,7 @@ class ChefProfileServiceTest {
   private MenuRepository menuRepository;
   private ReviewRepository reviewRepository;
   private ReservaRepository reservaRepository;
+  private ChefResolver chefResolver;
   private Authentication authentication;
 
   private Chef chef;
@@ -38,10 +40,11 @@ class ChefProfileServiceTest {
     menuRepository  = mock(MenuRepository.class);
     reviewRepository = mock(ReviewRepository.class);
     reservaRepository = mock(ReservaRepository.class);
+    chefResolver = mock(ChefResolver.class);
     authentication  = mock(Authentication.class);
 
     chefProfileService = new ChefProfileServiceImpl(
-      chefRepository, menuRepository, reviewRepository, reservaRepository
+      chefResolver, chefRepository, menuRepository, reviewRepository, reservaRepository
     );
 
     userLogin = mock(UserLogin.class);
@@ -142,8 +145,7 @@ class ChefProfileServiceTest {
     when(dto.getLanguages()).thenReturn(null);
     when(dto.getCoverPhoto()).thenReturn(null);
 
-    when(authentication.getName()).thenReturn("mario@example.com");
-    when(chefRepository.findByUser_Username("mario@example.com")).thenReturn(Optional.of(chef));
+    when(chefResolver.resolve(authentication)).thenReturn(chef);
     // findById es necesario porque updateChefProfile llama internamente a getChefPublicProfile(chef.getId())
     when(chefRepository.findById(1L)).thenReturn(Optional.of(chef));
 
@@ -165,8 +167,7 @@ class ChefProfileServiceTest {
   @Test
   void updateChefProfile_chefNotFound_throwsNoSuchElementException() {
     ChefUReqDto dto = mock(ChefUReqDto.class);
-    when(authentication.getName()).thenReturn("unknown@example.com");
-    when(chefRepository.findByUser_Username("unknown@example.com")).thenReturn(Optional.empty());
+    when(chefResolver.resolve(authentication)).thenThrow(new NoSuchElementException("Chef not found"));
 
     assertThrows(NoSuchElementException.class,
       () -> chefProfileService.updateChefProfile(authentication, dto));

--- a/src/backend/src/test/java/com/chefpro/service/impl/DishServiceTest.java
+++ b/src/backend/src/test/java/com/chefpro/service/impl/DishServiceTest.java
@@ -4,6 +4,7 @@ import com.chefpro.backendjava.common.object.dto.DishCReqDto;
 import com.chefpro.backendjava.common.object.dto.DishDto;
 import com.chefpro.backendjava.common.object.dto.DishUReqDto;
 import com.chefpro.backendjava.common.object.entity.*;
+import com.chefpro.backendjava.common.util.ChefResolver;
 import com.chefpro.backendjava.repository.*;
 import com.chefpro.backendjava.service.DishService;
 import com.chefpro.backendjava.service.impl.DishServiceImpl;
@@ -22,7 +23,7 @@ class DishServiceTest {
 
   private DishService dishService;
 
-  private ChefRepository chefRepository;
+  private ChefResolver chefResolver;
   private MenuRepository menuRepository;
   private DishRepository dishRepository;
   private AllergenDishRepository allergenDishRepository;
@@ -35,7 +36,7 @@ class DishServiceTest {
 
   @BeforeEach
   void setUp() {
-    chefRepository            = mock(ChefRepository.class);
+    chefResolver            = mock(ChefResolver.class);
     menuRepository            = mock(MenuRepository.class);
     dishRepository            = mock(DishRepository.class);
     allergenDishRepository    = mock(AllergenDishRepository.class);
@@ -43,7 +44,7 @@ class DishServiceTest {
     authentication            = mock(Authentication.class);
 
     dishService = new DishServiceImpl(
-      chefRepository, menuRepository, dishRepository,
+      chefResolver, menuRepository, dishRepository,
       allergenDishRepository, officialAllergenRepository
     );
 
@@ -61,7 +62,7 @@ class DishServiceTest {
     when(menu.getChef()).thenReturn(chef);
 
     when(authentication.getName()).thenReturn("mario@example.com");
-    when(chefRepository.findByUser_Username("mario@example.com")).thenReturn(Optional.of(chef));
+    when(chefResolver.resolve(authentication)).thenReturn(chef);
   }
 
   // ─── createDish ──────────────────────────────────────────────────────────
@@ -168,7 +169,7 @@ class DishServiceTest {
 
   @Test
   void getDish_chefNotFound_throwsRuntimeException() {
-    when(chefRepository.findByUser_Username("mario@example.com")).thenReturn(Optional.empty());
+    when(chefResolver.resolve(authentication)).thenThrow(new RuntimeException("Chef not found"));
 
     assertThrows(RuntimeException.class, () -> dishService.getDish(authentication, null));
     verifyNoInteractions(dishRepository);

--- a/src/backend/src/test/java/com/chefpro/service/impl/MenuServiceTest.java
+++ b/src/backend/src/test/java/com/chefpro/service/impl/MenuServiceTest.java
@@ -6,6 +6,7 @@ import com.chefpro.backendjava.common.object.dto.MenuUReqDto;
 import com.chefpro.backendjava.common.object.entity.Chef;
 import com.chefpro.backendjava.common.object.entity.Menu;
 import com.chefpro.backendjava.common.object.entity.UserLogin;
+import com.chefpro.backendjava.common.util.ChefResolver;
 import com.chefpro.backendjava.repository.ChefRepository;
 import com.chefpro.backendjava.repository.MenuRepository;
 import com.chefpro.backendjava.service.MenuService;
@@ -28,7 +29,7 @@ class MenuServiceTest {
     private MenuService menuService;
 
     private MenuRepository menuRepository;
-    private ChefRepository chefRepository;
+    private ChefResolver chefResolver;
     private Authentication authentication;
 
     // Entidades reutilizables
@@ -38,10 +39,10 @@ class MenuServiceTest {
     @BeforeEach
     void setUp() {
         menuRepository = mock(MenuRepository.class);
-        chefRepository = mock(ChefRepository.class);
+        chefResolver = mock(ChefResolver.class);
         authentication = mock(Authentication.class);
 
-        menuService = new MenuServiceImpl(menuRepository, chefRepository);
+        menuService = new MenuServiceImpl(menuRepository, chefResolver);
 
         // Construir entidades base
         userLogin = mock(UserLogin.class);
@@ -54,7 +55,7 @@ class MenuServiceTest {
         when(chef.getUser()).thenReturn(userLogin);
 
         when(authentication.getName()).thenReturn("chef@example.com");
-        when(chefRepository.findByUser_Username("chef@example.com")).thenReturn(Optional.of(chef));
+        when(chefResolver.resolve(authentication)).thenReturn(chef);
     }
 
     // ─── createMenu ──────────────────────────────────────────────────────────
@@ -79,9 +80,9 @@ class MenuServiceTest {
         MenuDTO result = menuService.createMenu(dto, authentication);
 
         assertNotNull(result);
-        assertEquals(10L, result.getId());
+        assertEquals(10L, result.getMenuId());
         assertEquals("Menú Mediterráneo", result.getTitle());
-        verify(chefRepository).findByUser_Username("chef@example.com");
+        verify(chefResolver).resolve(authentication);
         verify(menuRepository).save(any(Menu.class));
     }
 
@@ -109,13 +110,13 @@ class MenuServiceTest {
 
         assertNotNull(result);
         assertEquals(1, result.size());
-        verify(chefRepository).findByUser_Username("chef@example.com");
+        verify(chefResolver).resolve(authentication);
         verify(menuRepository).findByChefIdWithDishes(1L);
     }
 
     @Test
     void listByChef_chefNotFound_throwsRuntimeException() {
-        when(chefRepository.findByUser_Username("chef@example.com")).thenReturn(Optional.empty());
+        when(chefResolver.resolve(authentication)).thenThrow(new RuntimeException("Chef not found"));
 
         assertThrows(RuntimeException.class, () -> menuService.listByChef(authentication));
         verify(menuRepository, never()).findByChefIdWithDishes(any());
@@ -169,7 +170,7 @@ class MenuServiceTest {
         MenuDTO result = menuService.updateMenu(authentication, uReq);
 
         assertNotNull(result);
-        assertEquals(5L, result.getId());
+        assertEquals(5L, result.getMenuId());
         verify(menuRepository).save(menu);
     }
 


### PR DESCRIPTION
Resuelve todos los errores de compilación del backend que impedían ejecutar docker compose up. Los cambios incluyen: versión explícita de Lombok en annotationProcessorPaths, imports faltantes, campo dishes corregido en MenuDTO, llamadas al builder .menuId() corregidas, eliminación del bean CORS duplicado y actualización de los tests para que reflejen la API actual (renombrado de métodos, sustitución de ChefRepository por ChefResolver).